### PR TITLE
Continue the loop when the indices are skipped

### DIFF
--- a/blender/MapsModelsImporter/google_maps.py
+++ b/blender/MapsModelsImporter/google_maps.py
@@ -136,7 +136,8 @@ def filesToBlender(context, prefix, max_blocks=200):
     drawcallId = 0
     while max_blocks <= 0 or drawcallId < max_blocks:
         if not os.path.isfile("{}{:05d}-indices.bin".format(prefix, drawcallId)):
-            break
+            drawcallId += 1
+            continue
 
         try:
             indices, positions, uvs, img, constants = loadData(prefix, drawcallId)


### PR DESCRIPTION
This fix should address the bug for the case where the decoded files ids are not successive.

Example below: (indices jumped from `0001` to `0006`)
![Annotation 2019-11-23 230849](https://user-images.githubusercontent.com/317202/69486706-816b1680-0e46-11ea-961c-51a863aa2da5.png)

Previously it breaks the loop when it hit `0002` but this fix should continue the loop to next indices.